### PR TITLE
Revise and test examples in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Prescribed python code that defines the hashing algorithm for DLT Anchoring.
 Support
 =======
 
-This package currently is tested against Python versions 3.7,3.8,3.9 and 3.10.
+This package currently is tested against Python versions 3.7,3.8,3.9, 3.10 and 3.11.
 
 The current default version is 3.7 - this means that this package will not
 use any features specific to versions 3.8 and later.
@@ -34,69 +34,89 @@ If your version of python3 is too old an error of this type or similar will be e
     ERROR: Could not find a version that satisfies the requirement rkvst-simplehash (from versions: none)
     ERROR: No matching distribution found for rkvst-simplehash
 
-Example
+Examples
 =============
 
 You can then use the code to recreate the simple hash of a list of SIMPLE_HASH events from RKVST.
+
+Importing in own code
+.....................
 
 .. code:: python
 
     """From a list of events.
     """
 
-    from rkvst_simplehash.v1 import hash_events
+    from rkvst_simplehash.v1 import (
+        anchor_events,
+        SimpleHashError,
+    )
 
+    with open("credentials/token", mode="r", encoding="utf-8") as tokenfile:
+        auth_token = tokenfile.read().strip()
+
+    # SimpleHashClientAuthError is raised if the auth token is invalid or expired.
     # if any pending events a SimpleHashPendingEventFound error will be thrown
     # if any of the events do not contain the required field then a SimpleHashFieldMissing error will be thrown
+    try:
+        simplehash = anchor_events(
+            "2022-10-07 07:01:34Z",
+            "2022-10-16T13:14:56Z",
+            "app.rkvst.io",
+            auth_token,
+        )
+    except SimpleHashError as ex:
+        print("Error", ex)
 
-    simplehash = hash_events(events)
+    else:
+        print("simplehash=", simplehash)
 
 
 Command Line
 ------------
 
-This functionality is also available on the cmdline. Execute the simplehash query using curl and pip to the
-rkvst_simplehashv1 command or the v1.py script.
-
-Installing locally:
-....................
-
-Execute this after cloning the repo.
-
-.. code:: bash
-
-    python3 -m pip install bencode.py~=4.0
-
-    URL="https://app.rkvst.io/archivist/v2/assets/-/events"
-    SINCE=timestamp_accepted_since=2022-10-19T00:00:00Z
-    BEFORE=timestamp_accepted_before=2022-10-26T00:00:00Z
-    BEARER_TOKEN_FILE=credentials/token
-
-    curl -s -X GET \
-         -H "@$BEARER_TOKEN_FILE" \
-         "$URL?proof_mechanism=SIMPLE_HASH&${SINCE}&${BEFORE}" | rkvst_simplehash/v1.py
-
+This functionality is also available on the cmdline.
 
 Using a virtual env and published wheel:
 ........................................
 
 This can be executed anywhere using a virtualenv and published wheel.
+Credentials are stored in files in credentials directory.
+
+Using an auth token directly:
 
 .. code:: bash
 
+    #!/usr/bin/env bash
+    #
     python3 -m venv simplehash-venv
     source simplehash-venv/bin/activate
-    python3 -m pip install rkvst_simplehash
-
-    URL="https://app.rkvst.io/archivist/v2/assets/-/events"
-    SINCE=timestamp_accepted_since=2022-10-19T00:00:00Z
-    BEFORE=timestamp_accepted_before=2022-10-26T00:00:00Z
-    BEARER_TOKEN_FILE=credentials/token
-
-    curl -s -X GET \
-         -H "@$BEARER_TOKEN_FILE" \
-         "$URL?proof_mechanism=SIMPLE_HASH&${SINCE}&${BEFORE}" | rkvst_simplehashv1
-
+    python3 -m pip install -q rkvst_simplehash
+    
+    rkvst_simplehashv1 \
+        --auth-token-file "credentials/token" \
+        --start-time "2022-11-16T00:00:00Z" \
+        --end-time "2022-11-17T00:00:00Z"
+    
     deactivate
     rm -rf simplehash-venv
 
+Using a client id and secret:
+
+.. code:: bash
+
+    #!/usr/bin/env bash
+    #
+    python3 -m venv simplehash-venv
+    source simplehash-venv/bin/activate
+    python3 -m pip install -q rkvst_simplehash
+    
+    CLIENT_ID=$(cat credentials/client_id)
+    rkvst_simplehashv1 \
+        --client-id "${CLIENT_ID}" \
+        --client-secret-file "credentials/client_secret" \
+        --start-time "2022-11-16T00:00:00Z" \
+        --end-time "2022-11-17T00:00:00Z"
+    
+    deactivate
+    rm -rf simplehash-venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 #
 bencode.py~=4.0
+requests~=2.28

--- a/scripts/example1.sh
+++ b/scripts/example1.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Manual testing of the rkvst_simplehashv1 command.
+#
+# 'task wheel' to generate installable wheel package generated locally.
+#
+# Populate the credentials directory with auth token and change the fqdn field.
+# The auth token must be for a particular tenant identity.
+# Vary start and end time and execute such that:
+# 
+#    1. illegal url - check correct response
+#    2. bad token - check correct response
+#    3. vary start and endtimes and check that a simplehash is calculated.
+#
+python3 -m venv simplehash-venv
+source simplehash-venv/bin/activate
+python3 -m pip install -q --force-reinstall dist/rkvst_simplehash-*.whl
+
+rkvst_simplehashv1 \
+    --auth-token-file "credentials/token" \
+    --fqdn "app.rkvst-test.io" \
+    --start-time "2022-11-16T15:59:14Z" \
+    --end-time "2022-11-16T15:59:22Z"
+
+deactivate
+rm -rf simplehash-venv
+

--- a/scripts/example2.sh
+++ b/scripts/example2.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Manual testing of the rkvst_simplehashv1 command.
+#
+# 'task wheel' to generate installable wheel package generated locally.
+#
+# Populate the credentials directory with client id and secret and
+# change the fqdn field.
+# The credentials  must be for a particular tenant identity.
+# Vary start and end time and execute such that:
+#
+#    1. illegal url - check correct response
+#    2. bad token - check correct response
+#    3. vary start and endtimes and check that a simplehash is calculated.
+#
+python3 -m venv simplehash-venv
+source simplehash-venv/bin/activate
+python3 -m pip install -q --force-reinstall dist/rkvst_simplehash-*.whl
+
+CLIENT_ID=$(cat credentials/client_id)
+rkvst_simplehashv1 \
+    --client-id "${CLIENT_ID}" \
+    --client-secret-file "credentials/client_secret" \
+    --fqdn "app.rkvst-test.io" \
+    --start-time "2022-11-16T15:59:14Z" \
+    --end-time "2022-11-16T15:59:22Z"
+
+deactivate
+rm -rf simplehash-venv
+

--- a/unittests/mock_response.py
+++ b/unittests/mock_response.py
@@ -9,13 +9,20 @@ import json
 
 class MockResponse(dict):
     def __init__(
-        self, status_code, request=None, headers=None, iter_content=None, **kwargs
+        self,
+        status_code,
+        request=None,
+        headers=None,
+        iter_content=None,
+        exception=None,
+        **kwargs
     ):
         super().__init__(**kwargs)
         self.status_code = status_code
         self._headers = headers
         self._request = request
         self._iter_content = iter_content
+        self._exception = exception
 
     @property
     def url(self):
@@ -35,6 +42,10 @@ class MockResponse(dict):
 
     def json(self):
         return self
+
+    def raise_for_status(self):
+        if self._exception is not None:
+            raise self._exception
 
     def iter_content(self, chunk_size=4096):
         return self._iter_content(chunk_size=chunk_size)

--- a/unittests/testanchorevents.py
+++ b/unittests/testanchorevents.py
@@ -4,11 +4,14 @@ Test anchor_events method
 
 from unittest import TestCase, mock
 
+from requests import RequestException
+
 from rkvst_simplehash.v1 import (
     anchor_events,
     SimpleHashFieldError,
     SimpleHashFieldMissing,
     SimpleHashPendingEventFound,
+    SimpleHashRequestsError,
 )
 
 from .mock_response import MockResponse
@@ -416,4 +419,16 @@ class TestHashEventsV1(TestCase):
         mock_get.return_value = MockResponse(200, **NO_CONFIRMATION_EVENTS_RESPONSE)
 
         with self.assertRaises(SimpleHashFieldMissing):
+            dummy = anchor_events(MIN_ACCEPTED, MAX_ACCEPTED, FQDN, AUTH_TOKEN)
+
+    @mock.patch("rkvst_simplehash.v1.requests_get")
+    def test_anchor_events_v1_with_requests_exception(self, mock_get):
+        """
+        Test anchor_events
+        """
+        mock_get.return_value = MockResponse(
+            200, exception=RequestException, **PENDING_EVENTS_RESPONSE
+        )
+
+        with self.assertRaises(SimpleHashRequestsError):
             dummy = anchor_events(MIN_ACCEPTED, MAX_ACCEPTED, FQDN, AUTH_TOKEN)

--- a/unittests/testgetauthtoken.py
+++ b/unittests/testgetauthtoken.py
@@ -4,7 +4,8 @@ Test get_auth_token method
 
 from unittest import TestCase, mock
 
-from rkvst_simplehash.v1 import get_auth_token
+from requests import RequestException
+from rkvst_simplehash.v1 import get_auth_token, SimpleHashRequestsError
 
 from .mock_response import MockResponse
 
@@ -63,3 +64,20 @@ class TestGetAuthToken(TestCase):
             ACCESS_TOKEN,
             msg="TOKEN method called incorrectly",
         )
+
+    @mock.patch("rkvst_simplehash.v1.requests_post")
+    def test_get_auth_token_request_exception_v1(self, mock_post):
+        """
+        Test anchor_events
+        """
+
+        mock_post.return_value = MockResponse(
+            400, exception=RequestException, **RESPONSE
+        )
+
+        with self.assertRaises(SimpleHashRequestsError):
+            dummy = get_auth_token(
+                FQDN,
+                CLIENT_ID,
+                CLIENT_SECRET,
+            )


### PR DESCRIPTION
Problem:
Old examples from v0.1.2 are incorrect.

Solution:
Add tests scripts for examples described in README. Added handling of upstream HTTP errors.
Made example code 'quiet' to remove noisy messages.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>