### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Prescribed python code that defines the hashing algorithm for DLT Anchoring.
 Support
 =========
 
-This package currently is tested against Python versions 3.8,3.9, 3.10 and 3.11.
+This package currently is tested against Python versions 3.8,3.9,3.10,3.11 and 3.12.
 
 The current default version is 3.8 - this means that this package will not
 use any features specific to versions 3.8 and later.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,11 @@ tasks:
     cmds:
       - ./scripts/build.sh "3.11"
 
+  builder-3.12:
+    desc: Build a docker environment with the right dependencies and utilities
+    cmds:
+      - ./scripts/build.sh "3.12"
+
   check:
     desc: Check the style, bug and quality of the code
     cmds:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,13 @@
 
 # code quality
 autopep8~=2.0
-black~=23.7
-coverage[toml]~=7.2
+black~=23.9
+coverage[toml]~=7.3
 pip-audit~=2.6
 pycodestyle~=2.10
-pylint~=2.17
+pylint~=3.0
 xq~=0.0
 
 # uploading to pypi
-build~=0.10
+build~=1.0
 twine~=4.0


### PR DESCRIPTION
Upgrade pylint to 3.0 and other tools
Add support for python 3.12

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>